### PR TITLE
Added support for loading files as parameter values, including codecs…

### DIFF
--- a/stacker/config/translators/__init__.py
+++ b/stacker/config/translators/__init__.py
@@ -2,6 +2,8 @@ import yaml
 
 from .vault import vault_constructor
 from .kms import kms_simple_constructor
+from .file import file_constructor
 
 yaml.add_constructor('!vault', vault_constructor)
 yaml.add_constructor('!kms', kms_simple_constructor)
+yaml.add_constructor('!file', file_constructor)

--- a/stacker/config/translators/file.py
+++ b/stacker/config/translators/file.py
@@ -1,0 +1,113 @@
+import re
+import base64
+
+from .base import read_value_from_path
+from troposphere import GenericHelperFn, Base64
+
+def get_file_value(value):
+    """Translate a filename into the file contents, optionally encoding or interpolating the input
+
+    Fields should use the following format:
+
+        <codec>:<path>
+
+    For example:
+
+        # We've written a file to /some/path:
+        $ echo "hello there" > /some/path
+
+        # In stacker we would reference the contents of this file with the following
+        conf_key: !file plain:file://some/path
+
+        # The above would resolve to
+        conf_key: hello there
+
+        # Or, if we used wanted a base64 encoded copy of the file data
+        conf_key: !file base64:file://some/path
+
+        # The above would resolve to
+        conf_key: aGVsbG8gdGhlcmUK
+
+    Supported codecs:
+     - plain
+     - base64 - encode the plain text file at the given path with base64 prior
+       to returning it
+     - parameterized - the same as plain, but additionally supports
+       referencing template parameters to create userdata that's supplemented
+       with information from the template, as is commonly needed in EC2
+       UserData. For example, given a template parameter of BucketName, the
+       file could contain the following text:
+
+         #!/bin/sh
+         aws s3 sync s3://{{BucketName}}/somepath /somepath
+
+       and then you could use something like this in the YAML config file:
+
+         UserData: !file parameterized:/path/to/file
+
+       resulting in the UserData parameter being defined as:
+
+         { "Fn::Join" : ["", [
+           "#!/bin/sh\naws s3 sync s3://",
+           {"Ref" : "BucketName"},
+           "/somepath /somepath"
+         ]] }
+
+     - parameterized-b64 - the same as parameterized, with the results additionally
+       wrapped in { "Fn::Base64": ... } , which is what you actually need for
+       EC2 UserData
+
+    When using parameterized-b64 for UserData, you should use a local_parameter defined
+    as such:
+
+      "UserData": {
+        "description": "Instance user data",
+        "default": None
+      }
+
+    and then assign UserData in a LaunchConfiguration or Instance to self.local_parameters["UserData"]
+    """
+    try:
+        codec, path = value.split(":", 1)
+    except ValueError:
+        raise TypeError(
+            "File value must be of the format"
+            " \"<codec>:<path>\" (got %s)" % (value)
+        )
+
+    value = read_value_from_path(path)
+
+    return CODECS[codec](value)
+
+
+def userdata_codec(value, b64):
+    raw = read_value_from_path(value)
+    pattern = re.compile(r'{{(\w+)}}')
+
+    parts = []
+    s_index = 0
+
+    for match in pattern.finditer(raw):
+        parts.append(raw[s_index:match.start()])
+        parts.append({"Ref": match.group(1)})
+        s_index = match.end()
+
+    parts.append(raw[s_index:])
+    result = {"Fn::Join": ["", parts]}
+
+    # Note, since we want a raw JSON object (not a string) output in the template,
+    # we wrap the result in GenericHelperFn (not needed if we're using Base64)
+    return Base64(result) if b64 else GenericHelperFn(result)
+
+
+def file_constructor(loader, node):
+    value = loader.construct_scalar(node)
+    return get_file_value(value)
+
+
+CODECS = {
+    "plain": lambda x: x,
+    "base64": base64.b64encode,
+    "parameterized": lambda x: userdata_codec(x, False),
+    "parameterized-b64": lambda x: userdata_codec(x, True)
+}


### PR DESCRIPTION
Adds a translator to take a filename and return the file contents, optionally encoding or interpolating the input

Fields should use the following format:

    <codec>:<path>

For example:

    # We've written a file to /some/path:
    $ echo "hello there" > /some/path

    # In stacker we would reference the contents of this file with the following
    conf_key: !file plain:file://some/path

    # The above would resolve to
    conf_key: hello there

    # Or, if we used wanted a base64 encoded copy of the file data
    conf_key: !file base64:file://some/path

    # The above would resolve to
    conf_key: aGVsbG8gdGhlcmUK

    Supported codecs:
     - plain
     - base64 - encode the plain text file at the given path with base64 prior
       to returning it
     - parameterized - the same as plain, but additionally supports
       referencing template parameters to create userdata that's supplemented
       with information from the template, as is commonly needed in EC2
       UserData. For example, given a template parameter of BucketName, the
       file could contain the following text:

         #!/bin/sh
         aws s3 sync s3://{{BucketName}}/somepath /somepath

      and then you could use something like this in the YAML config file:

         UserData: !file parameterized:/path/to/file

      resulting in the UserData parameter being defined as:

         { "Fn::Join" : ["", [
           "#!/bin/sh\naws s3 sync s3://",
           {"Ref" : "BucketName"},
           "/somepath /somepath"
         ]] }

     - parameterized-b64 - the same as parameterized, with the results additionally
       wrapped in { "Fn::Base64": ... } , which is what you actually need for
       EC2 UserData

When using parameterized-b64 for UserData, you should use a local_parameter defined as such:

      "UserData": {
        "description": "Instance user data",
        "default": None
      }

    and then assign UserData in a LaunchConfiguration or Instance to self.local_parameters["UserData"]